### PR TITLE
Module maintenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,25 @@
 # Cache header support for Silverstripe
 
-
-Default Silverstripe cache handling [sends headers that are not considered cacheable](https://docs.silverstripe.org/en/4/developer_guides/performance/http_cache_headers/) by a proxy such as Cloudflare.
+The default Silverstripe cache handling sends headers that are not considered cacheable by a proxy such as Cloudflare.
 
 This module allows you to modify this behaviour via configuration, allowing a proxy to cache based on the headers sent by the application.
 
-> This module is in development and is not yet suitable for production environments
+## Useful information
 
-### Usage
+- [HTTP cache headers in Silverstripe](https://docs.silverstripe.org/en/4/developer_guides/performance/http_cache_headers/)
+- [MDN Cache-Control reference](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control)
+
+## Usage
 
 - Install this extension using composer
 - Modify the configuration rules to your requirements
-- Test behind your caching proxy and deploy
+- Test behind your caching proxy to verify Cache-Control and related header values are as expected
 
 ## Installation
 
 Install via composer:
-```
+
+```sh
 composer require nswdpc/silverstripe-cache-headers
 ```
 
@@ -53,6 +56,10 @@ See [documentation](./docs/en/001_index.md) for a primer on various options, inc
 We welcome bug reports, pull requests and feature requests on the Github Issue tracker for this project.
 
 Please review the [code of conduct](./code-of-conduct.md) prior to opening a new issue.
+
+## Security
+
+If you have found a security issue with this module, please email digital[@]dpc.nsw.gov.au in the first instance, detailing your findings.
 
 ## Development and contribution
 

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,6 @@
     "authors": [
         {
             "name": "James Ellis",
-            "homepage": "https://dpc.nsw.gov.au",
             "role": "Developer"
         }
     ],

--- a/composer.json
+++ b/composer.json
@@ -21,5 +21,18 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5"
+    },
+    "autoload": {
+        "psr-4": {
+            "NSWDPC\\Utilities\\Cache\\": [
+                "src/Control/Middleware/",
+                "src/Extensions/",
+                "src/Models/",
+                "src/Services/"
+            ],
+            "NSWDPC\\Utilities\\Cache\\Tests\\": [
+                "tests/"
+            ]
+        }
     }
 }

--- a/src/Control/Middleware/CacheHeaderProxyMiddleware.php
+++ b/src/Control/Middleware/CacheHeaderProxyMiddleware.php
@@ -97,7 +97,7 @@ class CacheHeaderProxyMiddleware extends HTTPCacheControlMiddleware {
 
         switch($state) {
             case HTTPCacheControlMiddleware::STATE_PUBLIC:
-                $this->publicCache(false, $maxAge);
+                $this->publicCache(false);
                 break;
             case HTTPCacheControlMiddleware::STATE_PRIVATE:
                 $this->privateCache(false);
@@ -106,7 +106,7 @@ class CacheHeaderProxyMiddleware extends HTTPCacheControlMiddleware {
                 $this->disableCache(false);
                 break;
             default:
-                $this->enableCache(false, $maxAge);
+                $this->enableCache(false);
                 break;
         }
 

--- a/src/Control/Middleware/CacheHeaderProxyMiddleware.php
+++ b/src/Control/Middleware/CacheHeaderProxyMiddleware.php
@@ -23,55 +23,69 @@ class CacheHeaderProxyMiddleware extends HTTPCacheControlMiddleware {
      * Flag that the applied state should be preferred
      * See {@link CacheStateModificationExtension} for an example
      */
-    public function useAppliedState() {
+    public function useAppliedState() : self {
         $this->useAppliedState = true;
         return $this;
     }
 
     /**
      * @inheritdoc
-     * Performs much the same as parent::augmentState() with the exception of
-     * a configired public/enabled cache being honoured when a session is active,
-     * which your application needs to handle
+     * parent::augmentState() with an additional step where cache state is set
+     * from configuration, provided the application has not set a state
      */
     protected function augmentState(HTTPRequest $request, HTTPResponse $response)
     {
+        parent::augmentState($request, $response);
 
-        // Errors and redirects disable cache
-        if ($response->isError() || $response->isRedirect()) {
-            $this->disableCache(true);
-        }
+        // If the application has made a change to the default framework state
+        // the forcing level will be set to >= 0
+        // and the default forcing level may be set
 
-        // Session is active
-        if ($request->getSession()->getAll()) {
-            // Honour private/disabled cache with active session
-            if( in_array($this->getState(), [ parent::STATE_DISABLED, parent::STATE_PRIVATE ]) ) {
-                return;
-            }
-        }
+        // if(!is_null($this->forcingLevel) || $this->config()->get('defaultForcingLevel') > 0) {
+        //    return;
+        // }
 
-        // If a specific cache state was applied in the application via self::useAppliedState()
-        // this should be honoured
+        // If a specific cache state was applied in the application
+        // via self::useAppliedState(), this should be honoured
         if($this->useAppliedState) {
             return;
         }
 
         // Apply state based on configuration
+        // this is where the configuration from the module is applied
         $this->applyConfiguredState();
 
     }
 
     /**
-     * Set the state based on configuration
-     * Use configuration to modify the state and directives
-     * The state is not forced, this allows the application to force a state
+     * Check if cache state has been modified beyond the default app/framwork configuration
+     */
+    public function inInitialState() : bool {
+        return ($this->getState() == $this->config()->get('defaultState'))
+            && (is_null($this->forcingLevel) || ($this->forcingLevel == $this->config()->get('defaultForcingLevel')));
+    }
+
+    /**
+     * Set the state based on configuration. Certain states preclude use of configured
+     * directive values.
+     *
+     * The state is not forced, this allows the application to force a state.
+     *
      * Forced states with higher precedence will be used in preference to
      * any configured state you set
-     * Example: if the configured state is 'public' and an application applies another state
-     * that state will be used, as publicCache has the lowest precedence
+     *
+     * Example: if the configured state is 'public' and an application applies
+     * another higher precedence state, that state will be used
+     *
      * @return void
      */
     protected function applyConfiguredState() {
+
+        // if the state has been changed at all...
+        if(!$this->inInitialState()) {
+            Logger::log("Not apply configured state as state has changed from default {$this->getState()}/{$this->forcingLevel}");
+            return;
+        }
 
         $state = CacheHeaderConfiguration::config()->get('state');
         $maxAge = CacheHeaderConfiguration::config()->get('max_age');
@@ -79,19 +93,7 @@ class CacheHeaderProxyMiddleware extends HTTPCacheControlMiddleware {
         $vary = CacheHeaderConfiguration::config()->get('vary');
         $mustRevalidate = CacheHeaderConfiguration::config()->get('must_revalidate');
         $noStore = CacheHeaderConfiguration::config()->get('no_store');
-
-        if(!is_null($vary)) {
-            $this->setVary($vary);
-        }
-        if(!is_null($sharedMaxAge)) {
-            $this->setSharedMaxAge($sharedMaxAge);
-        }
-        if(!is_null($mustRevalidate)) {
-            $this->setMustRevalidate($mustRevalidate);
-        }
-        if(!is_null($noStore)) {
-            $this->setNoStore($noStore);
-        }
+        $noCache = CacheHeaderConfiguration::config()->get('no_cache');
 
         switch($state) {
             case HTTPCacheControlMiddleware::STATE_PUBLIC:
@@ -99,9 +101,6 @@ class CacheHeaderProxyMiddleware extends HTTPCacheControlMiddleware {
                 break;
             case HTTPCacheControlMiddleware::STATE_PRIVATE:
                 $this->privateCache(false);
-                if (!is_null($maxAge)) {
-                    $this->setMaxAge($maxAge);
-                }
                 break;
             case HTTPCacheControlMiddleware::STATE_DISABLED:
                 $this->disableCache(false);
@@ -109,6 +108,36 @@ class CacheHeaderProxyMiddleware extends HTTPCacheControlMiddleware {
             default:
                 $this->enableCache(false, $maxAge);
                 break;
+        }
+
+        // Add/update Vary header value
+        if(!is_null($vary)) {
+            $this->setVary($vary);
+        }
+        // Add must-revalidate
+
+        if(!is_null($mustRevalidate)) {
+            $this->setMustRevalidate($mustRevalidate);
+        }
+
+        // Setting this value results in no-store, no-cache being removed
+        if (!is_null($maxAge)) {
+            $this->setMaxAge($maxAge);
+        }
+
+        // Setting this value results in no-store, no-cache being removed
+        if(!is_null($sharedMaxAge)) {
+            $this->setSharedMaxAge($sharedMaxAge);
+        }
+
+        // if no-cache is set, this will remove max-age directives
+        if(!is_null($noCache)) {
+            $this->setNoCache($noCache);
+        }
+
+        // If no-store is set, it will remove max-age directives
+        if(!is_null($noStore)) {
+            $this->setNoStore($noStore);
         }
 
     }

--- a/src/Control/Middleware/CacheHeaderProxyMiddleware.php
+++ b/src/Control/Middleware/CacheHeaderProxyMiddleware.php
@@ -24,7 +24,12 @@ class CacheHeaderProxyMiddleware extends HTTPCacheControlMiddleware {
      * See {@link CacheStateModificationExtension} for an example
      */
     public function useAppliedState() : self {
-        $this->useAppliedState = true;
+        if($this->getState() == parent::STATE_PUBLIC) {
+            Logger::log("Setting useAppliedState for public state will be ignored", "NOTICE");
+            $this->useAppliedState = false;
+        } else {
+            $this->useAppliedState = true;
+        }
         return $this;
     }
 
@@ -37,17 +42,9 @@ class CacheHeaderProxyMiddleware extends HTTPCacheControlMiddleware {
     {
         parent::augmentState($request, $response);
 
-        // If the application has made a change to the default framework state
-        // the forcing level will be set to >= 0
-        // and the default forcing level may be set
-
-        // if(!is_null($this->forcingLevel) || $this->config()->get('defaultForcingLevel') > 0) {
-        //    return;
-        // }
-
         // If a specific cache state was applied in the application
         // via self::useAppliedState(), this should be honoured
-        if($this->useAppliedState) {
+        if($this->useAppliedState && ($this->getState() != parent::STATE_PUBLIC)) {
             return;
         }
 

--- a/src/Extensions/CacheStateModificationExtension.php
+++ b/src/Extensions/CacheStateModificationExtension.php
@@ -6,7 +6,7 @@ use SilverStripe\Control\Middleware\HTTPCacheControlMiddleware;
 
 /**
  * Check project configuration for controller cache state configuration
- * Currently supports disabling cache (forced) on specific controllers
+ * Currently supports private or disable cache (forced) states on specific controllers
  */
 class CacheStateModificationExtension extends Extension {
 

--- a/src/Extensions/ContentControllerExtension.php
+++ b/src/Extensions/ContentControllerExtension.php
@@ -5,6 +5,7 @@ use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Core\Extension;
 use SilverStripe\Control\Middleware\HTTPCacheControlMiddleware;
 use SilverStripe\Security\InheritedPermissions;
+use SilverStripe\SiteConfig\SiteConfig;
 use SilverStripe\Versioned\Versioned;
 
 /**
@@ -16,38 +17,64 @@ class ContentControllerExtension extends Extension {
      * Handle actions after controller init
      */
     public function onAfterInit() {
-        // When on the live stage, determine if the page has restrictions
+        $this->applyRestrictedRecordCacheState();
+    }
+
+    /**
+     * When on the live stage, determine if the page has restrictions
+     * The draft stage defines its own cache state
+     */
+    private function applyRestrictedRecordCacheState() {
         $stage = Versioned::get_stage();
-        if($stage == Versioned::LIVE) {
-            $record = $this->owner->data();
-            if($record && ($record instanceof SiteTree) && !$this->hasAnyoneViewPermission($record)) {
-                HTTPCacheControlMiddleware::singleton()->disableCache()->useAppliedState();
-            }
+        if($stage != Versioned::LIVE) {
+            return;
+        }
+        $record = $this->owner->data();
+        if(!$record || !($record instanceof SiteTree)) {
+            // misconfiguration, disable cache
+            Logger::log("Controller has no record, calling disabledCache()", "NOTICE");
+            return $this->setDisableCacheState();
+        }
+        $siteConfig = $record->getSiteConfig();
+        if(!$siteConfig || !($siteConfig instanceof SiteConfig)) {
+            // misconfiguration, disable cache
+            Logger::log("Record is not a Siteconfig, calling disabledCache()", "NOTICE");
+            return $this->setDisableCacheState();
+        }
+        if($siteConfig->CanViewType !== InheritedPermissions::ANYONE) {
+            // restricted siteconfig setting
+            return $this->setDisableCacheState();
+        } else if(!$this->hasAnyoneViewPermission($record, $siteConfig)) {
+            // restricted sitetree record setting
+            return $this->setDisableCacheState();
         }
     }
 
     /**
+     * Disable the cache state, by calling disableCache
+     * and ensure that the state applied here is used
+     */
+    private function setDisableCacheState() {
+        HTTPCacheControlMiddleware::singleton()->disableCache(true)->useAppliedState();
+        return;
+    }
+
+    /**
      * Determine whether a SiteTree record can be viewed by anyone, taking into
-     * account site access settings and parent settings
+     * account parent settings and site config
      * @return bool
      */
-    private function hasAnyoneViewPermission(SiteTree $record) : bool {
-        // siteconfig check
-        $siteConfig = $record->getSiteConfig();
-        if($siteConfig && $siteConfig->CanViewType !== InheritedPermissions::ANYONE) {
-            return false;
-        }
+    private function hasAnyoneViewPermission(SiteTree $record, SiteConfig $siteConfig) : bool {
         if($record->CanViewType === InheritedPermissions::ANYONE) {
             // this record sets permissions
             return true;
         } else if ($record->CanViewType === InheritedPermissions::INHERIT) {
-            // inheriting from parent or site config
             if( ($parent = $record->Parent()) && $parent->exists() ) {
-                // record has parent
-                return $this->hasAnyoneViewPermission($parent);
+                // inheriting from parent
+                return $this->hasAnyoneViewPermission($parent, $siteConfig);
             } else {
-                // record has no parent, inherit from site config
-                return $siteConfig && $siteConfig->CanViewType === InheritedPermissions::ANYONE;
+                // record has no parent, site config check will pick this up
+                return $siteConfig->CanViewType === InheritedPermissions::ANYONE;
             }
         } else {
             // not

--- a/tests/AbstractCacheTest.php
+++ b/tests/AbstractCacheTest.php
@@ -2,6 +2,7 @@
 
 namespace NSWDPC\Utilities\Cache\Tests;
 
+use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Control\Director;
 use SilverStripe\Control\Middleware\HTTPCacheControlMiddleware;
@@ -33,6 +34,9 @@ abstract class AbstractCacheTest extends FunctionalTest {
     {
         parent::setUp();
         Director::config()->update('alternate_base_url', '/');
+
+        // Nested URLs must be true
+        Config::inst()->set(SiteTree::class, 'nested_urls', true);
 
         // Add test theme
         $themes = [

--- a/tests/AbstractCacheTest.php
+++ b/tests/AbstractCacheTest.php
@@ -16,6 +16,19 @@ use SilverStripe\View\SSViewer;
  */
 abstract class AbstractCacheTest extends FunctionalTest {
 
+    /**
+     * Perform operations prior to boot
+     * e.g. to avoid cache control modifiers in phpunit config
+     */
+    public static function start()
+    {
+        unset($_GET['flush']);
+        unset($_REQUEST['flush']);
+        unset($GLOBALS['_GET']['flush']);
+        unset($GLOBALS['_REQUEST']['flush']);
+        parent::start();
+    }
+
     protected function setUp() : void
     {
         parent::setUp();

--- a/tests/CacheStateModificationTest.php
+++ b/tests/CacheStateModificationTest.php
@@ -42,6 +42,8 @@ class CacheStateModificationTest extends AbstractCacheTest {
         CacheHeaderConfiguration::config()->set('max_age', $this->maxAge);
         CacheHeaderConfiguration::config()->set('s_max_age', $this->sMaxAge);
         CacheHeaderConfiguration::config()->set('must_revalidate', true);
+        CacheHeaderConfiguration::config()->set('no_cache', null);
+        CacheHeaderConfiguration::config()->set('no_store', null);
 
         // Configure controllers for CacheStateModificationExtension
         $controllers = [
@@ -66,15 +68,15 @@ class CacheStateModificationTest extends AbstractCacheTest {
         $body = $response->getBody();
 
         $headers = $response->getHeaders();
-        $this->assertTrue(!empty($headers['cache-control']), "no cache-control header in response");
+        $this->assertTrue(!empty($headers['cache-control']), "must have a cache-control response header");
 
         $parts = $this->getCacheControlParts($headers['cache-control']);
 
         $this->assertTrue( $this->hasCachingState($parts, HTTPCacheControlMiddleware::STATE_PRIVATE), "Header {$headers['cache-control']} has private state" );
-        $this->assertTrue( $this->hasCacheDirective($parts, "must-revalidate"), "Header {$headers['cache-control']} missing must-revalidate" );
+        $this->assertTrue( $this->hasCacheDirective($parts, "must-revalidate"), "Header {$headers['cache-control']} has must-revalidate" );
     }
 
-    public function testCacheStateModiicationDisable() {
+    public function testCacheStateModificationDisable() {
 
         $this->setSiteConfigCanViewType( InheritedPermissions::ANYONE );
 
@@ -83,13 +85,12 @@ class CacheStateModificationTest extends AbstractCacheTest {
         $body = $response->getBody();
 
         $headers = $response->getHeaders();
-        $this->assertTrue(!empty($headers['cache-control']), "no cache-control header in response");
+        $this->assertTrue(!empty($headers['cache-control']), "must have a cache-control response header");
 
         $parts = $this->getCacheControlParts($headers['cache-control']);
 
-        $this->assertFalse( $this->hasCachingState($parts, HTTPCacheControlMiddleware::STATE_PUBLIC), "Header {$headers['cache-control']} does not have public state" );
-        $this->assertTrue( $this->hasCacheDirective($parts, "no-store"), "Header {$headers['cache-control']} missing no-store" );
-        $this->assertTrue( $this->hasCacheDirective($parts, "no-cache"), "Header {$headers['cache-control']} missing no-cache" );
-        $this->assertTrue( $this->hasCacheDirective($parts, "must-revalidate"), "Header {$headers['cache-control']} missing must-revalidate" );
+        $this->assertFalse( $this->hasCachingState($parts, HTTPCacheControlMiddleware::STATE_DISABLED), "Header {$headers['cache-control']} has disabled state" );
+        $this->assertTrue( $this->hasCacheDirective($parts, "no-store") && $this->hasCacheDirective($parts, "no-cache"), "Header {$headers['cache-control']} has no-cache && no-store" );
+        $this->assertTrue( $this->hasCacheDirective($parts, "must-revalidate"), "Header {$headers['cache-control']} has must-revalidate" );
     }
 }

--- a/tests/PublicCacheTest.php
+++ b/tests/PublicCacheTest.php
@@ -44,6 +44,10 @@ class PublicCacheTest extends AbstractCacheTest {
 
     }
 
+
+    /**
+     * Test basic cache headers, header-test has a form
+     */
     public function testCacheHeaders() {
 
         // page has form, this should disableCache
@@ -52,50 +56,58 @@ class PublicCacheTest extends AbstractCacheTest {
 
         $this->assertTrue(strpos($body, "<h1>PUBLIC_CACHE_PAGE</h1>") !== false, "Content PUBLIC_CACHE_PAGE is not in response body");
         $headers = $response->getHeaders();
-        $this->assertTrue(!empty($headers['cache-control']), "no cache-control header in response");
+        $this->assertTrue(!empty($headers['cache-control']), "must have a cache-control response header");
 
         $parts = $this->getCacheControlParts($headers['cache-control']);
 
-        $this->assertFalse( $this->hasCachingState($parts, HTTPCacheControlMiddleware::STATE_PUBLIC), "Header {$headers['cache-control']} has public state" );
-        $this->assertTrue( $this->hasCacheDirective($parts, "no-cache"), "Header {$headers['cache-control']} missing no-cache" );
-        $this->assertTrue( $this->hasCacheDirective($parts, "no-store"), "Header {$headers['cache-control']} missing no-store" );
-        $this->assertTrue( $this->hasCacheDirective($parts, "must-revalidate"), "Header {$headers['cache-control']} missing must-revalidate" );
+        $this->assertFalse( $this->hasCachingState($parts, HTTPCacheControlMiddleware::STATE_PUBLIC), "Page 1 - Header {$headers['cache-control']} has public state" );
+        $this->assertTrue( $this->hasCacheDirective($parts, "no-cache") && $this->hasCacheDirective($parts, "no-store"), "Page 1 - Header {$headers['cache-control']} has no-cache && no-store" );
+        $this->assertTrue( $this->hasCacheDirective($parts, "must-revalidate"), "Page 1 - Header {$headers['cache-control']} missing must-revalidate" );
     }
 
+    /**
+     * Test basic cache headers where the page has no form
+     */
     public function testCacheHeadersWithNoForm() {
 
         // request and do not include form
         $response = $this->get("header-test/?noform=1");
         $headers = $response->getHeaders();
-        $this->assertTrue(!empty($headers['cache-control']), "no cache-control header in response");
+        $this->assertTrue(!empty($headers['cache-control']), "must have a cache-control response header");
 
         $parts = $this->getCacheControlParts($headers['cache-control']);
-        $this->assertTrue( $this->hasCachingState($parts, HTTPCacheControlMiddleware::STATE_PUBLIC), "Header {$headers['cache-control']} should be public" );
-        $this->assertTrue( $this->hasCacheDirective($parts, "must-revalidate"), "Header {$headers['cache-control']} missing must-revalidate" );
-        $this->assertTrue( $this->hasCacheDirective($parts, "s-maxage", "7401"), "Header {$headers['cache-control']} missing s-maxage=7401");
-        $this->assertTrue( $this->hasCacheDirective($parts, "max-age", "7301"), "Header {$headers['cache-control']} missing max-age=7301" );
+        $this->assertTrue( $this->hasCachingState($parts, HTTPCacheControlMiddleware::STATE_PUBLIC), "Page 1 - Header {$headers['cache-control']} is public" );
+        $this->assertTrue( $this->hasCacheDirective($parts, "must-revalidate"), "Page 1 - Header {$headers['cache-control']} has must-revalidate" );
+        $this->assertTrue( $this->hasCacheDirective($parts, "s-maxage", "7401"), "Page 1 - Header {$headers['cache-control']} has s-maxage=7401");
+        $this->assertTrue( $this->hasCacheDirective($parts, "max-age", "7301"), "Page 1 - Header {$headers['cache-control']} has max-age=7301" );
 
     }
 
-    // formcache=1 -> disableSecurityToken, set method = GET
+    /**
+     * Test page with a form that is allowed to cache
+     * formcache=1 -> disableSecurityToken, set method = GET
+     * the result should be public caching
+     */
     public function testCacheHeadersWithFormCache() {
 
         // request but turn off the security token and set to GET
-        // the result should be public caching
         $response = $this->get("header-test/?formcache=1");
         $headers = $response->getHeaders();
-        $this->assertTrue(!empty($headers['cache-control']), "no cache-control header in response");
+        $this->assertTrue(!empty($headers['cache-control']), "must have a cache-control response header");
 
         $parts = $this->getCacheControlParts($headers['cache-control']);
-        $this->assertTrue( $this->hasCachingState($parts, HTTPCacheControlMiddleware::STATE_PUBLIC), "Header {$headers['cache-control']} should be public" );
-        $this->assertTrue( $this->hasCacheDirective($parts, "must-revalidate"), "Header {$headers['cache-control']} missing must-revalidate" );
-        $this->assertTrue( $this->hasCacheDirective($parts, "s-maxage" , "7401"), "Header {$headers['cache-control']} missing s-maxage=7401");
-        $this->assertTrue( $this->hasCacheDirective($parts, "max-age", "7301"), "Header {$headers['cache-control']} missing max-age=7301" );
+        $this->assertTrue( $this->hasCachingState($parts, HTTPCacheControlMiddleware::STATE_PUBLIC), "Page 1 - Header {$headers['cache-control']} is public" );
+        $this->assertTrue( $this->hasCacheDirective($parts, "must-revalidate"), "Page 1 - Header {$headers['cache-control']} has must-revalidate" );
+        $this->assertTrue( $this->hasCacheDirective($parts, "s-maxage" , "7401"), "Page 1 - Header {$headers['cache-control']} has s-maxage=7401");
+        $this->assertTrue( $this->hasCacheDirective($parts, "max-age", "7301"), "Page 1 - Header {$headers['cache-control']} has max-age=7301" );
 
     }
 
-    // formcache=1 -> disableSecurityToken, set method = GET
-    // Test with form disableCache turned off but with a session
+    /**
+     * formcache=1 -> disableSecurityToken, set method = GET
+     * Test with form disableCache turned off but with a session
+     * Result should be private cache
+     */
     public function testCacheHeadersWithFormCacheLoggedIn() {
 
         // log in - disable cache
@@ -103,103 +115,119 @@ class PublicCacheTest extends AbstractCacheTest {
         // request but turn off the security token and set to GET
         $response = $this->get("header-test/?formcache=1");
         $headers = $response->getHeaders();
-        $this->assertTrue(!empty($headers['cache-control']), "no cache-control header in response");
+        $this->assertTrue(!empty($headers['cache-control']), "Page 1 - must have a cache-control response header");
         $parts = $this->getCacheControlParts($headers['cache-control']);
-        $this->assertFalse( $this->hasCachingState($parts, HTTPCacheControlMiddleware::STATE_PRIVATE), "Header {$headers['cache-control']} should be private" );
-        $this->assertTrue( $this->hasCacheDirective($parts, "must-revalidate"), "Header {$headers['cache-control']} missing must-revalidate" );
+        $this->assertTrue( $this->hasCacheDirective($parts, HTTPCacheControlMiddleware::STATE_PRIVATE), "Page 1 - Header {$headers['cache-control']} should be private" );
+        $this->assertTrue( $this->hasCacheDirective($parts, "must-revalidate"), "Page 1 - Header {$headers['cache-control']} missing must-revalidate" );
 
     }
 
     /**
-     * Tests based on CanViewType
+     * Tests based on CanViewType, with no form
      */
     public function testCanViewRootPage() {
         // Inherit (root page)
         $response = $this->get("/header-test/?noform=1");
         $headers = $response->getHeaders();
-        $this->assertTrue(!empty($headers['cache-control']), "Page 1 - no cache-control header in response");
+        $this->assertTrue(!empty($headers['cache-control']), "Page 1 - must have a cache-control response header");
         $parts = $this->getCacheControlParts($headers['cache-control']);
-        $this->assertTrue( $this->hasCacheDirective($parts, "public"), "Page 1 - Header {$headers['cache-control']} missing public" );
+        $this->assertTrue( $this->hasCacheDirective($parts, "public"), "Page 1 - Header {$headers['cache-control']} has public" );
 
     }
 
+    /**
+     * Tests with can view anyone
+     */
     public function testCanViewSubPageAnyone() {
         // Anyone page under root should be public
         $response = $this->get("/header-test/sub-page-header-test/?noform=1");
         $headers = $response->getHeaders();
-        $this->assertTrue(!empty($headers['cache-control']), "Page 2 - no cache-control header in response");
+        $this->assertTrue(!empty($headers['cache-control']), "Page 2 - must have a cache-control response header");
         $parts = $this->getCacheControlParts($headers['cache-control']);
-        $this->assertTrue( $this->hasCacheDirective($parts, "public"), "Page 2 - Header {$headers['cache-control']} missing public" );
+        $this->assertTrue( $this->hasCacheDirective($parts, "public"), "Page 2 - Header {$headers['cache-control']} has public" );
     }
 
+    /**
+     * Tests sub page with "only these users" restriction
+     * Result should not be public cache
+     */
     public function testCanViewSubPageOnlyTheseUsers() {
         // OnlyTheseUsers should not be public
         $response = $this->get("/header-test/restricted-page-header-test/?noform=1");
         $headers = $response->getHeaders();
-        $this->assertTrue(!empty($headers['cache-control']), "Page 3 - no cache-control header in response");
+        $this->assertTrue(!empty($headers['cache-control']), "Page 3 - must have a cache-control response header");
         $parts = $this->getCacheControlParts($headers['cache-control']);
-        $this->assertTrue( $this->hasCacheDirective($parts, "no-cache"), "Page 3 - Header {$headers['cache-control']} missing no-cache" );
-        $this->assertTrue( $this->hasCacheDirective($parts, "no-store"), "Page 3 - Header {$headers['cache-control']} missing no-store" );
-        $this->assertTrue( $this->hasCacheDirective($parts, "must-revalidate"), "Page 3 - Header {$headers['cache-control']} missing must-revalidate" );
+        $this->assertTrue( $this->hasCacheDirective($parts, "no-cache") && $this->hasCacheDirective($parts, "no-store"), "Page 3 - Header {$headers['cache-control']} has no-cache && no-store" );
+        $this->assertTrue( $this->hasCacheDirective($parts, "must-revalidate"), "Page 3 - Header {$headers['cache-control']} has must-revalidate" );
     }
 
+    /**
+     * Tests sub page with logged in user restriction
+     * Result should not be public cache
+     */
     public function testCanViewSubPageLoggedInUsers() {
         // LoggedInUsers page should not be public
         $response = $this->get("/header-test/loggedin-page-header-test/?noform=1");
         $headers = $response->getHeaders();
-        $this->assertTrue(!empty($headers['cache-control']), "Page 4 - no cache-control header in response");
+        $this->assertTrue(!empty($headers['cache-control']), "Page 4 - must have a cache-control response header");
         $parts = $this->getCacheControlParts($headers['cache-control']);
-        $this->assertTrue( $this->hasCacheDirective($parts, "no-cache"), "Page 4 - Header {$headers['cache-control']} missing no-cache" );
-        $this->assertTrue( $this->hasCacheDirective($parts, "no-store"), "Page 4 - Header {$headers['cache-control']} missing no-store" );
-        $this->assertTrue( $this->hasCacheDirective($parts, "must-revalidate"), "Page 4 - Header {$headers['cache-control']} missing must-revalidate" );
+        $this->assertTrue( $this->hasCacheDirective($parts, "no-cache") && $this->hasCacheDirective($parts, "no-store"), "Page 4 - Header {$headers['cache-control']} has no-cache && no-store" );
+        $this->assertTrue( $this->hasCacheDirective($parts, "must-revalidate"), "Page 4 - Header {$headers['cache-control']} has must-revalidate" );
     }
 
+    /**
+     * Test inherited view=anyone page
+     */
     public function testCanViewSubPageInheritedAnyone() {
         // Inherited from parent page with Anyone - should bge public
         $response = $this->get("/header-test/sub-page-header-test/inherited-anyone-page-header-test/?noform=1");
         $headers = $response->getHeaders();
-        $this->assertTrue(!empty($headers['cache-control']), "Page 5 - no cache-control header in response");
+        $this->assertTrue(!empty($headers['cache-control']), "Page 5 - must have a cache-control response header");
         $parts = $this->getCacheControlParts($headers['cache-control']);
-        $this->assertTrue( $this->hasCacheDirective($parts, "public"), "Page 5 - Header {$headers['cache-control']} missing public" );
+        $this->assertTrue( $this->hasCacheDirective($parts, "public"), "Page 5 - Header {$headers['cache-control']} has public" );
     }
 
+    /**
+     * Test inherited sub page, with OnlyTheseUsers permission
+     * should not be public
+     */
     public function testCanViewSubPageInheritedOnlyTheseUsers() {
         // Inherited from parent page with OnlyTheseUsers set - not public
         $response = $this->get("/header-test/restricted-page-header-test/inherited-restricted-page-header-test/?noform=1");
         $headers = $response->getHeaders();
-        $this->assertTrue(!empty($headers['cache-control']), "Page 6 - no cache-control header in response");
+        $this->assertTrue(!empty($headers['cache-control']), "Page 6 - must have a cache-control response header");
         $parts = $this->getCacheControlParts($headers['cache-control']);
-        $this->assertTrue( $this->hasCacheDirective($parts, "no-cache"), "Page 6 - Header {$headers['cache-control']} missing no-cache" );
-        $this->assertTrue( $this->hasCacheDirective($parts, "no-store"), "Page 6 - Header {$headers['cache-control']} missing no-store" );
-        $this->assertTrue( $this->hasCacheDirective($parts, "must-revalidate"), "Page 6 - Header {$headers['cache-control']} missing must-revalidate" );
+        $this->assertTrue( $this->hasCacheDirective($parts, "no-cache") && $this->hasCacheDirective($parts, "no-store"), "Page 6 - Header {$headers['cache-control']} has no-cache && no-store" );
+        $this->assertTrue( $this->hasCacheDirective($parts, "must-revalidate"), "Page 6 - Header {$headers['cache-control']} has must-revalidate" );
     }
 
     /**
      * Restrict SiteConfig to Logged In Users and test root page (Inherit)
+     * Should not be public
      */
     public function testCanViewRestrictedRootPage() {
         $this->setSiteConfigCanViewType( InheritedPermissions::LOGGED_IN_USERS );
         $response = $this->get("/parentless-test/?noform=1");
         $headers = $response->getHeaders();
-        $this->assertTrue(!empty($headers['cache-control']), "Page 7 - no cache-control header in response");
+        $this->assertTrue(!empty($headers['cache-control']), "Page 7 - must have a cache-control response header");
         $parts = $this->getCacheControlParts($headers['cache-control']);
-        $this->assertTrue( $this->hasCacheDirective($parts, "no-cache"), "Page 7 - Header {$headers['cache-control']} missing no-cache" );
-        $this->assertTrue( $this->hasCacheDirective($parts, "no-store"), "Page 7 - Header {$headers['cache-control']} missing no-store" );
-        $this->assertTrue( $this->hasCacheDirective($parts, "must-revalidate"), "Page 7 - Header {$headers['cache-control']} missing must-revalidate" );
+        $this->assertTrue( $this->hasCacheDirective($parts, "no-cache") && $this->hasCacheDirective($parts, "no-store"), "Page 7 - Header {$headers['cache-control']} has no-cache && no-store" );
+        $this->assertTrue( $this->hasCacheDirective($parts, "must-revalidate"), "Page 7 - Header {$headers['cache-control']} has must-revalidate" );
         $this->setSiteConfigCanViewType( InheritedPermissions::ANYONE );
     }
 
     /**
-     * Sub Page anyone, but restricted site config - not public
+     * Sub Page anyone, but restricted site config
+     * Result should not be public cache
      */
     public function testCanViewRestrictedSubPageAnyone() {
         $this->setSiteConfigCanViewType( InheritedPermissions::LOGGED_IN_USERS );
         $response = $this->get("/header-test/sub-page-header-test/?noform=1");
         $headers = $response->getHeaders();
-        $this->assertTrue(!empty($headers['cache-control']), "Page 2 - no cache-control header in response");
+        $this->assertTrue(!empty($headers['cache-control']), "Page 2 - must have a cache-control response header");
         $parts = $this->getCacheControlParts($headers['cache-control']);
-        $this->assertTrue( $this->hasCacheDirective($parts, "public"), "Page 2 - Header {$headers['cache-control']} missing no-cache" );
-        $this->assertTrue( $this->hasCacheDirective($parts, "must-revalidate"), "Page 2 - Header {$headers['cache-control']} missing must-revalidate" );
+        $this->assertTrue( $this->hasCacheDirective($parts, "no-cache") && $this->hasCacheDirective($parts, "no-store"), "Page 2 - Header {$headers['cache-control']} has no-cache && no-store" );
+        $this->assertTrue( $this->hasCacheDirective($parts, "must-revalidate"), "Page 2 - Header {$headers['cache-control']} has must-revalidate" );
         $this->setSiteConfigCanViewType( InheritedPermissions::ANYONE );
     }
 


### PR DESCRIPTION
This PR brings a few modifications:

- a modification to augementState. The parent middleware augmentState response is not duplicated
- the state defined in configuration is only applied if the initial state from framework configuration has been altered (e.g  the current state is not the default state, or a forcing level was defined)
- cache options defined in the configuration are applied after the state is set, as the state defined which options can be applied
- restricted pages are delivered with a disabled cache state, rather than private cache state
- If SiteConfig defines a restricted site, this is taken into account first
- psr-4 config
- some updates to documentation